### PR TITLE
fix: marketplace workflow id typo

### DIFF
--- a/marketplace/src/workflows/marketplace/delete-vendor-admin/index.ts
+++ b/marketplace/src/workflows/marketplace/delete-vendor-admin/index.ts
@@ -16,7 +16,7 @@ export type DeleteVendorAdminWorkflow = {
 }
 
 export const deleteVendorAdminWorkflow = createWorkflow(
-  "delete-restaurant-admin",
+  "delete-vendor-admin",
   (
     input: WorkflowData<DeleteVendorAdminWorkflow>
   ): WorkflowResponse<string> => {


### PR DESCRIPTION
while installing all examples in same project I found this small typo