### PR TITLE
binary -> base64 as of v2.11.0

### DIFF
--- a/digital-product/src/api/admin/digital-products/upload/[type]/route.ts
+++ b/digital-product/src/api/admin/digital-products/upload/[type]/route.ts
@@ -24,7 +24,7 @@ export const POST = async (
       files: input?.map((f) => ({
         filename: f.originalname,
         mimeType: f.mimetype,
-        content: f.buffer.toString("binary"),
+        content: f.buffer.toString("base64"),
         access,
       })),
     },


### PR DESCRIPTION
## Summary

**What** — What changes are introduced in this PR?

- Doc updates 

**Why** — Why are these changes relevant or necessary?  

- v2.11.0 changed the file processing workflow - It now expects base64 content by default

**How** — How have these changes been implemented?

- Modifying binary to base64

**Testing** — How have these changes been tested, or how can the reviewer test the feature?

- Tested fix locally and on my medusa production instances

---

## Examples

```ts
import {
  AuthenticatedMedusaRequest,
  MedusaResponse,
} from "@medusajs/framework/http";
import { uploadFilesWorkflow } from "@medusajs/medusa/core-flows";
import { MedusaError } from "@medusajs/framework/utils";

export const POST = async (
  req: AuthenticatedMedusaRequest,
  res: MedusaResponse
) => {
  const access = req.params.type === "main" ? "private" : "public";
  const input = req.files as Express.Multer.File[];

  if (!input?.length) {
    throw new MedusaError(
      MedusaError.Types.INVALID_DATA,
      "No files were uploaded"
    );
  }

  const { result } = await uploadFilesWorkflow(req.scope).run({
    input: {
      files: input?.map((f) => ({
        filename: f.originalname,
        mimeType: f.mimetype,
        content: f.buffer.toString("base64"),
        access,
      })),
    },
  });

  res.status(200).json({ files: result });
};

```

---

## Checklist

Please ensure the following before requesting a review:

- [ ] I have added a **changeset** for this PR
    - Every non-breaking change should be marked as a **patch**
    - To add a changeset, run `yarn changeset` and follow the prompts
- [x] The changes are covered by relevant **tests**
- [x] I have verified the code works as intended locally
- [ ] I have linked the related issue(s) if applicable

---

## Additional Context

Another related issue that I have not been able to resolve is duplicate entries into ``digital_product_media`` table for every media uploaded. Each unique ``fileId`` will have 2 entries in the table with their own unique ``id``. 