### PR TITLE
fix(subscription): support multiple account holders per customer

### DIFF
--- a/subscription/src/workflows/create-subscription-order/index.ts
+++ b/subscription/src/workflows/create-subscription-order/index.ts
@@ -39,7 +39,7 @@ const createSubscriptionOrderWorkflow = createWorkflow(
         "cart.payment_collection.*",
         "cart.payment_collection.payment_sessions.*",
         "cart.customer.*",
-        "cart.customer.account_holder.*",
+        "cart.customer.account_holders.*",
       ],
       filters: {
         id: input.subscription.id

--- a/subscription/src/workflows/create-subscription-order/steps/get-payment-method.ts
+++ b/subscription/src/workflows/create-subscription-order/steps/get-payment-method.ts
@@ -4,7 +4,7 @@ import { createStep, StepResponse } from "@medusajs/framework/workflows-sdk"
 
 export interface GetPaymentMethodStepInput {
   customer?: CustomerDTO & {
-    account_holder: AccountHolderDTO
+    account_holders: AccountHolderDTO[]
   }
 }
 
@@ -21,7 +21,12 @@ export const getPaymentMethodStep = createStep(
   async ({ customer }: GetPaymentMethodStepInput, { container }) => {
     const paymentModuleService = container.resolve(Modules.PAYMENT)
 
-    if (!customer?.account_holder) {
+    const providerId = "pp_stripe_stripe"
+    const accountHolder = customer?.account_holders?.find(
+      (ah) => ah.provider_id === providerId
+    )
+
+    if (!accountHolder) {
       throw new MedusaError(
         MedusaError.Types.INVALID_DATA,
         "No account holder found for the customer while retrieving payment method"
@@ -31,9 +36,9 @@ export const getPaymentMethodStep = createStep(
     const paymentMethods = await paymentModuleService.listPaymentMethods(
       {
         // you can change to other payment provider
-        provider_id: "pp_stripe_stripe",
+        provider_id: providerId,
         context: {
-          account_holder: customer.account_holder,
+          account_holder: accountHolder,
         },
       },
     )
@@ -49,7 +54,7 @@ export const getPaymentMethodStep = createStep(
 
     return new StepResponse(
       paymentMethodToUse,
-      customer.account_holder
+      accountHolder
     )
   }
 )


### PR DESCRIPTION
## What
Updates the subscription example's `getPaymentMethodStep` and the
create-subscription-order workflow to work with the one-to-many
Customer <> AccountHolder link.

## Why
Since Medusa v2.7.0, the link between `Customer` and `AccountHolder`
is one-to-many: a customer can have multiple account holders (one per
payment provider). The singular `account_holder` relation no longer
exists, so `customer.account_holder` and querying
`cart.customer.account_holder.*` are invalid.

## Changes
- Query `cart.customer.account_holders.*` instead of the removed
  `account_holder` relation.
- In `getPaymentMethodStep`, find the account holder for the Stripe
  provider from the `account_holders` list by `provider_id`, and
  throw if none is found.

This mirrors the fix applied to the subscriptions recipe in the docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)