### PR TITLE
fix(agentic-commerce): align webhooks with ACP 2026-04-17

### DIFF
--- a/agentic-commerce/README.md
+++ b/agentic-commerce/README.md
@@ -1,11 +1,34 @@
 # Medusa v2 Example: Agentic Commerce
 
-This directory holds the code for the [Agentic Commerce Tutorial](https://docs.medusajs.com/resources/integrations/guides/algolia).
+This directory holds the code for the [Agentic Commerce Tutorial](https://docs.medusajs.com/resources/how-to-tutorials/tutorials/agentic-commerce).
 
 You can either:
 
 - [install and use it as a Medusa application](#installation);
 - or [copy its source files into an existing Medusa application](#copy-into-existing-medusa-application).
+
+## ACP Compatibility
+
+This example targets the published ACP `2026-04-17` Agentic Checkout and webhook schemas.
+
+| Capability | Status | Production boundary |
+|---|---|---|
+| Product-feed generation | Example implementation | `sendProductFeed` only logs the generated feed. Implement authenticated transport and delivery monitoring. |
+| Checkout session routes | Example implementation | Authentication is intentionally disabled in the sample middleware. Enable and test it before deployment. |
+| POST idempotency | Partial | Routes pass the key to workflow context, but production deployments must enforce required, replay, in-flight, and payload-conflict behavior. |
+| Delegated payment | Stripe example | Validate provider eligibility, failure recovery, reconciliation, and safe logging for your deployment. |
+| Order webhooks | Schema-aligned payload example | Event names, order statuses, adjustments, and signing follow `2026-04-17`; webhook delivery remains merchant-supplied. |
+
+This compatibility statement describes the example's implementation surface. It is not a certification or a statement that a merchant is enabled in any host product, region, or rollout cohort.
+
+Before using this example in production:
+
+- enable and test bearer authentication;
+- enforce the ACP version and required idempotency behavior;
+- implement product-feed and webhook transport, retry, and monitoring;
+- store signing secrets securely and rotate them through an approved process;
+- validate checkout, payment, order, refund, and fulfillment scenarios for your business;
+- compare the pinned ACP release with newer releases before upgrading.
 
 ## Prerequisites
 
@@ -122,6 +145,8 @@ You can then test out the integration with ChatGPT or other AI agents based on t
 
 ## More Resources
 
-- [Medusa Documentatin](https://docs.medusajs.com)
+- [Medusa Documentation](https://docs.medusajs.com)
 - [Agentic Commerce documentation](https://developers.openai.com/commerce)
+- [ACP `2026-04-17` Agentic Checkout schema](https://github.com/agentic-commerce-protocol/agentic-commerce-protocol/blob/main/spec/2026-04-17/openapi/openapi.agentic_checkout.yaml)
+- [ACP `2026-04-17` webhook schema](https://github.com/agentic-commerce-protocol/agentic-commerce-protocol/blob/main/spec/2026-04-17/openapi/openapi.agentic_checkout_webhook.yaml)
 - [OpenAPI Spec file](https://res.cloudinary.com/dza7lstvk/raw/upload/v1759332538/OpenApi/agentic-commerce-openapi_hvsioq.yaml): Can be imported into tools like Postman to view and send requests to this project's API routes.

--- a/agentic-commerce/src/modules/agentic-commerce/__tests__/service.unit.spec.ts
+++ b/agentic-commerce/src/modules/agentic-commerce/__tests__/service.unit.spec.ts
@@ -1,0 +1,36 @@
+import crypto from "crypto"
+import AgenticCommerceService from "../service"
+
+describe("AgenticCommerceService", () => {
+  it("creates an ACP 2026-04-17 Merchant-Signature header", () => {
+    const service = new AgenticCommerceService({}, {
+      signatureKey: "test_secret",
+    })
+    const timestamp = 1_700_000_000
+    const rawBody = JSON.stringify({
+      type: "order_create",
+      data: { id: "ord_123" },
+    })
+    const expectedDigest = crypto
+      .createHmac("sha256", "test_secret")
+      .update(`${timestamp}.${rawBody}`, "utf8")
+      .digest("hex")
+
+    expect(service.getWebhookSignature(rawBody, timestamp)).toBe(
+      `t=${timestamp},v1=${expectedDigest}`
+    )
+  })
+
+  it("signs the exact raw body", () => {
+    const service = new AgenticCommerceService({}, {
+      signatureKey: "test_secret",
+    })
+    const timestamp = 1_700_000_000
+
+    expect(
+      service.getWebhookSignature('{"a":1,"b":2}', timestamp)
+    ).not.toBe(
+      service.getWebhookSignature('{"b":2,"a":1}', timestamp)
+    )
+  })
+})

--- a/agentic-commerce/src/modules/agentic-commerce/__tests__/service.unit.spec.ts
+++ b/agentic-commerce/src/modules/agentic-commerce/__tests__/service.unit.spec.ts
@@ -2,6 +2,21 @@ import crypto from "crypto"
 import AgenticCommerceService from "../service"
 
 describe("AgenticCommerceService", () => {
+  it("preserves the base64 signature used for inbound requests", async () => {
+    const service = new AgenticCommerceService({}, {
+      signatureKey: "test_secret",
+    })
+    const payload = { id: "checkout_123" }
+    const expectedSignature = crypto
+      .createHmac("sha256", "test_secret")
+      .update(JSON.stringify(payload), "utf8")
+      .digest("base64")
+
+    await expect(service.getSignature(payload)).resolves.toBe(
+      expectedSignature
+    )
+  })
+
   it("creates an ACP 2026-04-17 Merchant-Signature header", () => {
     const service = new AgenticCommerceService({}, {
       signatureKey: "test_secret",

--- a/agentic-commerce/src/modules/agentic-commerce/service.ts
+++ b/agentic-commerce/src/modules/agentic-commerce/service.ts
@@ -61,6 +61,11 @@ export default class AgenticCommerceService {
     }
   }
 
+  async getSignature(data: any) {
+    return Buffer.from(crypto.createHmac('sha256', this.options.signatureKey)
+      .update(JSON.stringify(data), 'utf8').digest()).toString('base64')
+  }
+
   getWebhookSignature(
     rawBody: string,
     timestamp = Math.floor(Date.now() / 1000)

--- a/agentic-commerce/src/modules/agentic-commerce/service.ts
+++ b/agentic-commerce/src/modules/agentic-commerce/service.ts
@@ -1,15 +1,19 @@
 import crypto from "crypto"
 
 export type AgenticCommerceWebhookEvent = {
-  type: "order.created" | "order.updated"
+  type: "order_create" | "order_update"
   data: {
     type: "order"
+    id: string
     checkout_session_id: string
     permalink_url: string
-    status: "created" | "manual_review" | "confirmed" | "canceled" | "shipping" | "fulfilled"
-    refunds: {
-      type: "store_credit" | "original_payment"
-      amount: number
+    status: "created" | "manual_review" | "confirmed" | "processing" | "shipped" | "completed" | "canceled"
+    adjustments: {
+      id: string
+      type: "refund"
+      occurred_at: string
+      status: "completed"
+      amount?: number
     }[]
   }
 }
@@ -57,18 +61,25 @@ export default class AgenticCommerceService {
     }
   }
 
-  async getSignature(data: any) {
-    return Buffer.from(crypto.createHmac('sha256', this.options.signatureKey)
-      .update(JSON.stringify(data), 'utf8').digest()).toString('base64')
+  getWebhookSignature(
+    rawBody: string,
+    timestamp = Math.floor(Date.now() / 1000)
+  ) {
+    const digest = crypto
+      .createHmac("sha256", this.options.signatureKey)
+      .update(`${timestamp}.${rawBody}`, "utf8")
+      .digest("hex")
+
+    return `t=${timestamp},v1=${digest}`
   }
 
   async sendWebhookEvent({
     type,
     data
   }: AgenticCommerceWebhookEvent) {
-    // Create signature
-    const signature = this.getSignature(data)
+    const rawBody = JSON.stringify({ type, data })
+    const signature = this.getWebhookSignature(rawBody)
     // TODO send order webhook event
-    console.log(`Sent order webhook event ${type} with signature ${signature} and data ${JSON.stringify(data)}`)
+    console.log(`Prepared order webhook event ${type} with Merchant-Signature ${signature}`)
   }
 }

--- a/agentic-commerce/src/subscribers/__tests__/order-webhook.unit.spec.ts
+++ b/agentic-commerce/src/subscribers/__tests__/order-webhook.unit.spec.ts
@@ -1,0 +1,107 @@
+import { buildOrderWebhookEvent } from "../order-webhook"
+
+const baseOrder = {
+  id: "ord_123",
+  status: "pending",
+  cart: { id: "cart_123" },
+  transactions: [],
+}
+
+describe("buildOrderWebhookEvent", () => {
+  it("maps a placed order to order_create", () => {
+    const event = buildOrderWebhookEvent(
+      { ...baseOrder, fulfillments: [] },
+      "order.placed",
+      "https://store.example.com"
+    )
+
+    expect(event).toEqual({
+      type: "order_create",
+      data: {
+        type: "order",
+        id: "ord_123",
+        checkout_session_id: "cart_123",
+        permalink_url: "https://store.example.com/orders/ord_123",
+        status: "confirmed",
+        adjustments: [],
+      },
+    })
+  })
+
+  it("does not treat an empty fulfillment list as shipped", () => {
+    const event = buildOrderWebhookEvent(
+      { ...baseOrder, fulfillments: [] },
+      "order.updated",
+      "https://store.example.com"
+    )
+
+    expect(event.data.status).toBe("confirmed")
+  })
+
+  it("maps fully shipped fulfillments to shipped", () => {
+    const event = buildOrderWebhookEvent(
+      {
+        ...baseOrder,
+        fulfillments: [
+          { shipped_at: "2026-07-28T10:00:00Z" },
+          { shipped_at: "2026-07-28T11:00:00Z" },
+        ],
+      },
+      "order.updated",
+      "https://store.example.com"
+    )
+
+    expect(event.data.status).toBe("shipped")
+  })
+
+  it("evaluates completed before shipped", () => {
+    const event = buildOrderWebhookEvent(
+      {
+        ...baseOrder,
+        fulfillments: [{
+          shipped_at: "2026-07-28T10:00:00Z",
+          delivered_at: "2026-07-29T10:00:00Z",
+        }],
+      },
+      "order.updated",
+      "https://store.example.com"
+    )
+
+    expect(event.data.status).toBe("completed")
+  })
+
+  it("maps canceled orders to canceled", () => {
+    const event = buildOrderWebhookEvent(
+      { ...baseOrder, status: "canceled", fulfillments: [] },
+      "order.updated",
+      "https://store.example.com"
+    )
+
+    expect(event.data.status).toBe("canceled")
+  })
+
+  it("maps refund transactions to adjustments", () => {
+    const event = buildOrderWebhookEvent(
+      {
+        ...baseOrder,
+        fulfillments: [],
+        transactions: [{
+          id: "txn_refund_123",
+          reference: "refund",
+          amount: -1500,
+          created_at: "2026-07-29T12:00:00Z",
+        }],
+      },
+      "order.updated",
+      "https://store.example.com"
+    )
+
+    expect(event.data.adjustments).toEqual([{
+      id: "txn_refund_123",
+      type: "refund",
+      occurred_at: "2026-07-29T12:00:00.000Z",
+      status: "completed",
+      amount: 1500,
+    }])
+  })
+})

--- a/agentic-commerce/src/subscribers/__tests__/order-webhook.unit.spec.ts
+++ b/agentic-commerce/src/subscribers/__tests__/order-webhook.unit.spec.ts
@@ -88,7 +88,7 @@ describe("buildOrderWebhookEvent", () => {
         transactions: [{
           id: "txn_refund_123",
           reference: "refund",
-          amount: -1500,
+          amount: -15,
           created_at: "2026-07-29T12:00:00Z",
         }],
       },

--- a/agentic-commerce/src/subscribers/order-webhook.ts
+++ b/agentic-commerce/src/subscribers/order-webhook.ts
@@ -5,6 +5,75 @@ import type {
 import { AGENTIC_COMMERCE_MODULE } from "../modules/agentic-commerce"
 import { AgenticCommerceWebhookEvent } from "../modules/agentic-commerce/service"
 
+type OrderWebhookInput = {
+  id: string
+  status: string
+  cart: {
+    id: string
+  } | null
+  fulfillments?: ({
+    shipped_at?: string | Date | null
+    delivered_at?: string | Date | null
+  } | null)[] | null
+  transactions?: ({
+    id: string
+    reference?: string | null
+    amount: number
+    created_at: string | Date
+  } | null)[] | null
+}
+
+export function buildOrderWebhookEvent(
+  order: OrderWebhookInput,
+  eventName: string,
+  storefrontUrl: string
+): AgenticCommerceWebhookEvent {
+  if (!order.cart) {
+    throw new Error("Cannot build an ACP order webhook without a cart")
+  }
+
+  const fulfillments = (order.fulfillments || []).filter(
+    (fulfillment): fulfillment is NonNullable<typeof fulfillment> =>
+      !!fulfillment
+  )
+  let status: AgenticCommerceWebhookEvent["data"]["status"] = "confirmed"
+
+  if (order.status === "canceled") {
+    status = "canceled"
+  } else if (
+    fulfillments.length > 0 &&
+    fulfillments.every((fulfillment) => !!fulfillment.delivered_at)
+  ) {
+    status = "completed"
+  } else if (
+    fulfillments.length > 0 &&
+    fulfillments.every((fulfillment) => !!fulfillment.shipped_at)
+  ) {
+    status = "shipped"
+  }
+
+  return {
+    type: eventName === "order.placed" ? "order_create" : "order_update",
+    data: {
+      type: "order",
+      id: order.id,
+      checkout_session_id: order.cart.id,
+      permalink_url: `${storefrontUrl}/orders/${order.id}`,
+      status,
+      adjustments: order.transactions?.filter(
+        (transaction): transaction is NonNullable<typeof transaction> =>
+          !!transaction && transaction.reference === "refund"
+      ).map((transaction) => ({
+        id: transaction.id,
+        type: "refund",
+        occurred_at: new Date(transaction.created_at).toISOString(),
+        status: "completed",
+        amount: Math.abs(transaction.amount),
+      })) || [],
+    }
+  }
+}
+
 export default async function orderWebhookHandler({
   event: { data, name },
   container,
@@ -14,6 +83,10 @@ export default async function orderWebhookHandler({
   const agenticCommerceModuleService = container.resolve(AGENTIC_COMMERCE_MODULE)
   const configModule = container.resolve("configModule")
   const storefrontUrl = configModule.admin.storefrontUrl || process.env.STOREFRONT_URL
+
+  if (!storefrontUrl) {
+    throw new Error("A storefront URL is required to send ACP order webhooks")
+  }
 
   const { data: [order] } = await query.graph({
     entity: "order",
@@ -34,34 +107,7 @@ export default async function orderWebhookHandler({
     return
   }
 
-  const webhookEvent: AgenticCommerceWebhookEvent = {
-    type: name === "order.placed" ? "order.created" : "order.updated",
-    data: {
-      type: "order",
-      checkout_session_id: order.cart.id,
-      permalink_url: `${storefrontUrl}/orders/${order.id}`,
-      status: "confirmed",
-      refunds: order.transactions?.filter(
-        (transaction) => transaction?.reference === "refund"
-      ).map((transaction) => ({
-        type: "original_payment",
-        amount: transaction!.amount * -1,
-      })) || [],
-    }
-  }
-
-  // set status
-  if (order.status === "canceled") {
-    webhookEvent.data.status = "canceled"
-  } else {
-    const allFulfillmentsShipped = order.fulfillments?.every((fulfillment) => !!fulfillment?.shipped_at)
-    const allFulfillmentsDelivered = order.fulfillments?.every((fulfillment) => !!fulfillment?.delivered_at)
-    if (allFulfillmentsShipped) {
-      webhookEvent.data.status = "shipping"
-    } else if (allFulfillmentsDelivered) {
-      webhookEvent.data.status = "fulfilled"
-    }
-  }
+  const webhookEvent = buildOrderWebhookEvent(order, name, storefrontUrl)
 
   await agenticCommerceModuleService.sendWebhookEvent(webhookEvent)
 }

--- a/agentic-commerce/src/subscribers/order-webhook.ts
+++ b/agentic-commerce/src/subscribers/order-webhook.ts
@@ -68,7 +68,7 @@ export function buildOrderWebhookEvent(
         type: "refund",
         occurred_at: new Date(transaction.created_at).toISOString(),
         status: "completed",
-        amount: Math.abs(transaction.amount),
+        amount: Math.abs(transaction.amount) * 100,
       })) || [],
     }
   }


### PR DESCRIPTION
## What changed

- document that the example targets the published ACP `2026-04-17` release and clarify its production boundaries
- align order webhook event names, order statuses, refund adjustments, and `Merchant-Signature` generation with that release
- fix fulfillment mapping so an empty fulfillment list is not treated as shipped and delivered orders reach `completed`
- add focused unit coverage for webhook lifecycle mapping and inbound and outbound signing

## Why

The example used webhook names, status values, refund fields, and signature formatting that differ from the published ACP `2026-04-17` schemas. That can make an otherwise working Medusa integration emit payloads a conforming receiver cannot process.

This PR keeps the scope reviewable. Authentication, complete idempotency enforcement, and production webhook transport remain explicit follow-up work.

## Impact

Developers using the example get a pinned compatibility target, schema-aligned order webhook payloads, and clearer guidance about what must be completed before production use.

## Validation

- `yarn test:unit` — 2 suites, 9 tests passed
- `yarn build` — backend and frontend builds passed

Refs #101